### PR TITLE
Bugfix: i3-persist can now be properly used on floating windows

### DIFF
--- a/src/i3-persist-common.sh
+++ b/src/i3-persist-common.sh
@@ -2,7 +2,7 @@ TMP_DIR="/tmp/i3-persist"
 
 # Returns the id of the currently focused container
 get_focused_container_id() {
-  i3-msg -t get_tree | jq "recurse(.nodes[]) | select(.focused == true) | .id"
+  i3-msg -t get_tree | jq "recurse(.nodes[], .floating_nodes[]) | select(.focused == true) | .id" 2>/dev/null
 }
 
 # Returns the ids of all child containers. Includes the parent. Form: newline-separated


### PR DESCRIPTION
Title. 
Same change should probably be added to `get_parent_and_all_child_container_ids()` in `i3-persist-common.sh` but I didn't have time for research and debug.